### PR TITLE
Replaced granite-orm with granite

### DIFF
--- a/guides/models/granite/README.md
+++ b/guides/models/granite/README.md
@@ -11,7 +11,7 @@ Add this library to your projects dependencies along with the driver in your `sh
 ```yaml
 dependencies:
   granite_orm:
-    github: amberframework/granite-orm
+    github: amberframework/granite
 
   # Pick your database
   mysql:


### PR DESCRIPTION
In shard.yaml, the Granite ORM was being added as `amberframework/granite-orm`. But the GitHub repo https://github.com/amberframework/granite-orm is archived. So, replaced `amberframework/granite-orm` with `amberframework/granite`.