### PR TITLE
Ensure MacPorts software index is up to date prior to installing Amber port

### DIFF
--- a/getting-started/quick-start.md
+++ b/getting-started/quick-start.md
@@ -30,6 +30,7 @@ Installing Amber with these package managers also installs Crystal.
 - MacPorts
 
   ```text
+  sudo port selfupdate
   sudo port install amber
   ```
  

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -68,5 +68,6 @@ Installing Amber with these package managers also installs Crystal.
 - MacPorts
 
   ```text
+  sudo port selfupdate
   sudo port install amber
   ```


### PR DESCRIPTION
The purpose of this PR is to ensure that the MacPorts software index is up to date prior to installing the Amber port.