### PR TITLE
Improve mailer docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -45,7 +45,6 @@
     * [Sockets](guides/websockets/sockets.md)
     * [JavaScript Client](guides/websockets/javascript-client.md)
   * [Mailers](guides/mailers/README.md)
-    * [Deliver a new Email](guides/mailers/deliver-a-new-email.md)
 * [Testing](testing/README.md)
   * [System Tests](testing/system-tests.md)
 * [Deployment](deployment/README.md)
@@ -87,4 +86,3 @@
 * [Ask on StackOverflow](https://stackoverflow.com/questions/tagged/amber-framework)
 * [Follow on Twitter](https://twitter.com/amberframework)
 * [Submit an issue](https://github.com/amberframework/amber/issues)
-

--- a/guides/mailers/README.md
+++ b/guides/mailers/README.md
@@ -1,20 +1,41 @@
 # Mailers
 
-The mailer has the ability to set the`from`,`to`,`cc`,`bcc`,`subject`and`body`. You may use the`render`helper to create the body of the email.
+Mailers are implemented using the [Quartz-Mailer](https://github.com/amberframework/quartz-mailer) library. This library is not required by default so you must require it in a config file.
 
 ```ruby
-class WelcomeMailer < Quartz::Mailer
-  def initialize
-    super
-    from "Amber Crystal", "info@ambercr.io"
+# config/mailer.cr
+
+require "quartz_mailer"
+
+### If you use a base mailer class you must require it before the others
+#require "../src/mailers/base_mailer" 
+
+require "../src/mailers/**"
+```
+
+## Define a Mailer
+
+The mailer has the ability to set the `from`, `to`, `cc`, `bcc`, and `subject` as well as both `text` and `html` body formats. You may use the `render` helper to create the body of the email.
+
+```ruby
+class WelcomeMailer < Quartz::Composer
+  def sender
+    address email: "info@amberframework.org", name: "Amber"
   end
 
-  def deliver(name: String, email: String)
-    to name: name, email: email
+  def initialize(name : String, email : String)
+    to email: email, name: name # Can be called multiple times to add more recipients
+
     subject "Welcome to Amber"
-    body render("mailers/welcome_mailer.slang", "mailer.slang")
-    super()
+
+    text render("mailers/welcome_mailer.text.ecr")
+    html render("mailers/welcome_mailer.html.slang", "mailer-layout.html.slang")
   end
 end
 ```
 
+## Deliver an Email
+
+```ruby
+WelcomeMailer.new(name, email).deliver
+```

--- a/guides/mailers/deliver-a-new-email.md
+++ b/guides/mailers/deliver-a-new-email.md
@@ -1,9 +1,0 @@
-# Deliver a new Email
-
-To delivery a new email:
-
-```ruby
-mailer = WelcomeMailer.new
-mailer.deliver(name, email)
-```
-


### PR DESCRIPTION
Improves the mailer docs in the following ways:

- Mailer not required by default. Includes instruction on how to require it
- Deliver a new Email page moved to main Mailer instructions because both documents were too short
- Fix bug in argument types definition for `deliver` method