### PR TITLE
Fix syntax error for SQL create index command.

### DIFF
--- a/guides/models/granite/associations.md
+++ b/guides/models/granite/associations.md
@@ -220,8 +220,8 @@ CREATE TABLE participants (
   updated_at TIMESTAMP
 );
 
-CREATE INDEX 'user_id_idx' ON TABLE participants (user_id);
-CREATE INDEX 'room_id_idx' ON TABLE participants (room_id);
+CREATE INDEX user_id_idx ON participants (user_id);
+CREATE INDEX room_id_idx ON participants (room_id);
 ```
 
 ## has_many through:


### PR DESCRIPTION
Based on the docs, we shouldn't use quotes and there is no `TABLE` in the command. This was causing errors when I ran it locally.

https://www.postgresql.org/docs/9.1/sql-createindex.html