### PR TITLE
Update the find_by syntax

### DIFF
--- a/guides/models/granite/querying.md
+++ b/guides/models/granite/querying.md
@@ -90,7 +90,7 @@ end
 ### Find By
 
 ```ruby
-post = Post.find_by :slug, "example_slug"
+post = Post.find_by slug: "example_slug"
 if post
   puts post.name
 end


### PR DESCRIPTION
For granite, `Post.find_by :slug, "example_slug"` generates an error. Per the [granite docs](https://docs.amberframework.org/granite/docs/crud#find_by) this looks like it is expecting a key/value pair (**args)