### PR TITLE
Fix HTTP status code in Halt example

### DIFF
--- a/guides/controllers/halt.md
+++ b/guides/controllers/halt.md
@@ -7,13 +7,13 @@ When you want a request to cease and return a particular message rather then ren
 ```ruby
 class UserController < ApplicationController
   def index
-    halt!(404, "Forbidden") if params[:user_id].nil?
+    halt!(403, "Forbidden") if params[:user_id].nil?
     render "index.slang"
   end
 end
 ```
 
-A status code of `404` was returned, and the content in `render` will not be delivered to the client.
+A status code of `403` was returned, and the content in `render` will not be delivered to the client.
 
 The next time you’re building an Amber application, consider using halt to simplify error handling.
 


### PR DESCRIPTION
While the example's semantic seems to demonstrate a forbidden
access case, the chosen status code should be 403 instead of 404.

See: [404 Not Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404)
See: [403 Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403)