### PR TITLE
Add missing dependencies for Ubuntu at getting-started

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -48,7 +48,7 @@ sudo apt-get install build-essential crystal
 Then install Amber \(from source\)
 
 ```text
-sudo apt-get install libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev libyaml-dev
+sudo apt-get install libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev libyaml-dev libpcre3-dev libevent-dev
 curl -L https://github.com/amberframework/amber/archive/stable.tar.gz | tar xz
 cd amber-stable/
 shards install


### PR DESCRIPTION
## Problem
On Unbuntu, when following the [getting started instructions](https://docs.amberframework.org/amber/getting-started), running `shards install` fails because of the absence of `libevent-dev` and `libpcre3-dev`.

## What this PR does
Modifies the first instruction of the block after `Then install Amber (from source)`, to:
> sudo apt-get install libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev libyaml-dev libevent-dev libpcre3-dev


