### PR TITLE
Add reference to CodeLLDB in crystal-debug.md

### DIFF
--- a/examples/crystal-debug.md
+++ b/examples/crystal-debug.md
@@ -6,7 +6,7 @@ This tutorial has tips and tricks on how to debug Crystal projects. It shows how
 
 * Crystal - See installation guide [here](https://crystal-lang.org/docs/installation/)
 * Crystal project - See installation guide [here](https://crystal-lang.org/docs/using_the_compiler/#creating-a-project-or-library) or [here \(Amber\)](../guides/installation.md)
-* VSCode with [Crystal Lang](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) and [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) extensions
+* VSCode with [Crystal Lang](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) and [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) or [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extensions
 * GNU debugger \(GDB\) or LLVM debugger \(LLDB\) - See installation guide below
 
 Install `gdb` or `lldb` accordingly to your OS.

--- a/examples/crystal-debug.md
+++ b/examples/crystal-debug.md
@@ -12,7 +12,7 @@ This tutorial has tips and tricks on how to debug Crystal projects. It shows how
 Install `gdb` or `lldb` accordingly to your OS.
 
 {% hint style="info" %}
-Confirm that the above prerequisites are installed before setting up the debugger. These settings have been verified for a MacOS and Linux's environments.
+Confirm that the above prerequisites are installed before setting up the debugger. These settings have been verified for mac OS and Linux environments.
 {% endhint %}
 
 ## Debug on VSCode


### PR DESCRIPTION
I'm having success inspecting local variables using the [CodeLLDB](https://github.com/crystal-lang/crystal/issues/4457#issuecomment-723830178) extension.