### PR TITLE
Adds hint about docker for local development in databases

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -80,6 +80,10 @@ If you don’t already have one of these installed, please follow the guides pro
 On OS X any of the databases can be installed with `brew install [database]`
 {% endhint %}
 
+{% hint style="info" %}
+Docker users can opt to use a database container to develop with as well. By default, a new Amber application generates a `docker-compose.yml` that can be used for this purpose. 
+{% endhint %}
+
 ## 2. Generate a new Amber application
 
 With all dependencies successfully installed, we can generate a new application with `amber new`


### PR DESCRIPTION
Adds a hint about using a Docker container for the database instances instead of installing to the host machine in the database section. This is helpful for scanning through the documentation for the first time to avoid installing database packages on host machine
