### PR TITLE
Add missing documentation for controller methods

### DIFF
--- a/guides/controllers/README.md
+++ b/guides/controllers/README.md
@@ -35,6 +35,31 @@ end
 
 As an example, if a user goes to `api/index` in your application to add a new client, Amber will create an instance of **ApiController** and call it's **index** method
 
+### Passing data to views
+
+Any local variable declared in the controller method will be available in the rendered view.  For example:
+
+```ruby
+class OrdersController < ApplicationController
+  def index
+    unfilled_orders = Order.where(fulfilled: false).select
+    render("index.html.ecr")
+  end
+end
+```
+
+Then in your view you can do:
+
+```ruby
+unfilled_orders.each do |order|
+<tr>
+  <td> <%= order.order_number %> </td>
+  <td> <%= order.customer.email %> </td>
+  ...
+</tr>
+end
+```
+
 ## Actions Conventions
 
 While actions can be named anything we like, there are conventions for action names which you should adhere whenever possible. We went over these in the Routing Guide, but we’ll take another quick look here.


### PR DESCRIPTION
All the examples of passing data to views use class variables.

However, Crystal Compiler will complain if you do this and the examples do not compile.

The compiler will force you to do things like init the variable at the class level.  This has the potential to share memory across concurrent requests.  Until I figured this out I wasted time doing things like:

```ruby
class MyController
  @orders = [] of Order

  def view_orders
    @orders = Order.all
    render("view_orders.html.ecr")
  end
end
```

Instead of the more convenient

```ruby
class MyController
  def view_orders
    orders = Order.all
    render("view_orders.html.ecr")
  end
end
```