### PR TITLE
Fixed typo in new.md

### DIFF
--- a/cli/new.md
+++ b/cli/new.md
@@ -34,7 +34,7 @@ See the **Recipes** option of the **Command Line Tool** for information about us
 Using `amber new microsecond-blog` will generate a skeleton Amber application in `./microsecond-blog`. You can have a running web application in a matter of minutes:
 
 ```text
-amber new microsecond-blog -s sqlite
+amber new microsecond-blog -d sqlite
 cd microsecond-blog
 amber watch
 open http://localhost:3000


### PR DESCRIPTION
Hi team 
Thank you so much for making such a wonderful tool.
In amber, the database choice flag is `-d`. In the example of document, it is printed `-s`, so I modify it.

## Problem
```bash
amber new blog -s sqlite
# Parsing Error: The -s option is unknown.
```